### PR TITLE
Fix cast class exceptions for Int conversations.

### DIFF
--- a/simplify/src/main/java/org/cf/simplify/strategy/ConstantPropigationStrategy.java
+++ b/simplify/src/main/java/org/cf/simplify/strategy/ConstantPropigationStrategy.java
@@ -149,8 +149,14 @@ public class ConstantPropigationStrategy implements OptimizationStrategy {
     static BuilderInstruction buildConstant(Object value, int register, DexBuilder dexBuilder) {
         String type = getUnboxedType(TypeUtil.getValueType(value));
         BuilderInstruction result = null;
-        if (type.equals("I") || type.equals("B") || type.equals("S") || type.equals("C")) {
+        if (type.equals("I")) {
             result = buildConstant((Integer) value, register);
+        } else if (type.equals("B")) {
+            result = buildConstant(((Byte) value).intValue(), register);
+        } else if (type.equals("S")) {
+            result = buildConstant(((Short) value).intValue(), register);
+        } else if (type.equals("C")) {
+            result = buildConstant(((Character) value).charValue(), register);
         } else if (type.equals("Z")) {
             result = buildConstant(((Boolean) value), register);
         } else if (type.equals("J")) {

--- a/simplify/src/test/java/org/cf/simplify/strategy/TestConstantPropigationStrategy.java
+++ b/simplify/src/test/java/org/cf/simplify/strategy/TestConstantPropigationStrategy.java
@@ -2,6 +2,7 @@ package org.cf.simplify.strategy;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 import gnu.trove.map.TIntObjectMap;
 import gnu.trove.map.hash.TIntObjectHashMap;
 import gnu.trove.set.TIntSet;
@@ -19,6 +20,20 @@ import org.slf4j.LoggerFactory;
 
 @RunWith(Enclosed.class)
 public class TestConstantPropigationStrategy {
+
+    public static class SimpleValues {
+        @Test
+	    public void testIntCasts() {
+            try {
+                ConstantPropigationStrategy.buildConstant(Integer.valueOf(10), 0, null);
+                ConstantPropigationStrategy.buildConstant(Byte.valueOf((byte) 0), 0, null);
+                ConstantPropigationStrategy.buildConstant(Short.valueOf((short) 0), 0, null);
+                ConstantPropigationStrategy.buildConstant(Character.valueOf('D'), 0, null);
+            } catch (Exception exception) {
+                fail("Exception occured while building constants : " + exception);
+            }
+        }
+    }
 
     public static class WithKnownValues {
         @Test


### PR DESCRIPTION
Character, Short and Byte (proper with capitalizations)
do not directly cast properly to Integer. The code now
properly casts and uses the helper methods provided
by the classes to convert it to an int (which is cleanly
cast seemlessly to Integer).
