### PR TITLE
Prevent UnknownValue class-cast exceptions.

### DIFF
--- a/smalivm/src/test/java/org/cf/smalivm/opcode/TestFilledNewArray.java
+++ b/smalivm/src/test/java/org/cf/smalivm/opcode/TestFilledNewArray.java
@@ -4,6 +4,7 @@ import gnu.trove.map.TIntObjectMap;
 
 import org.cf.smalivm.VMTester;
 import org.cf.smalivm.context.MethodState;
+import org.cf.smalivm.type.UnknownValue;
 import org.junit.Test;
 
 public class TestFilledNewArray {
@@ -13,8 +14,19 @@ public class TestFilledNewArray {
     @Test
     public void testFilledNewArrayOp() {
         TIntObjectMap<Object> initial = VMTester.buildRegisterState(0, 2, 1, 3, 2, 5);
-        TIntObjectMap<Object> expected = VMTester.buildRegisterState(MethodState.ResultRegister,
-                        new int[] { 2, 3, 5 });
+	TIntObjectMap<Object> expected = VMTester.buildRegisterState(MethodState.ResultRegister, new int[] { 2, 3, 5 });
+
+	VMTester.testMethodState(CLASS_NAME, "TestFilledNewArray()V", initial, expected);
+    }
+
+    /*
+     * Ensure that any UnknownValue in a register causes the return state to be an UnknownValue Integer array
+     */
+    @Test
+    public void testFilledNewArrayOpUnknownValue() {
+	TIntObjectMap<Object> initial = VMTester.buildRegisterState(0, 2, 1, 3, 2, new UnknownValue("I"));
+        TIntObjectMap<Object> expected = VMTester
+	    .buildRegisterState(MethodState.ResultRegister, new UnknownValue("[I"));
 
         VMTester.testMethodState(CLASS_NAME, "TestFilledNewArray()V", initial, expected);
     }


### PR DESCRIPTION
When encountering an UnknownValue inside a
filled-new-array, the opcode object should
return an UnknownValue integer array, otherwise
dragons can happen.
