### PR TITLE
Add travis-ci and coveralls file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,22 @@
+language: java
+jdk:
+    - oraclejdk8
+    - oraclejdk7
+
+env:
+    - TERM=dumb
+
+before_install:
+    - chmod +x gradlew
+
+script:
+    - ./gradlew clean test build shadow
+
+after_success:
+    - ./gradlew jacocoTestReport coveralls
+
+sudo: false
+
+cache:
+    directories:
+        - $HOME/.gradle

--- a/README.md
+++ b/README.md
@@ -1,12 +1,14 @@
 Simplify
 ========
 
+[![Build Status](https://travis-ci.org/calebfenton/simplify.svg?branch=master)](https://travis-ci.org/calebfenton/simplify) [![Coverage Status](https://img.shields.io/coveralls/calebfenton/simplify.svg)](https://coveralls.io/r/calebfenton/simplify)
+
 Generic Android Deobfuscator
 ----------------------------
 
 Simplify uses a virtual machine to understand what an app does. Then, it applies optimizations to create code that behaves identically, but is easier for a human to understand. Specifically, it takes Smali files as input and outputs a Dex file with (hopefully) identical semantics but less complicated structure.
 
-For example, if an app's strings are encrypted, Simplify will interpret the app in its own virtual machine to determine semantics. Then, it uses the apps own code to decrypt the strings and replaces the encrypted strings and the decryption method calls with the decrypted versions. It's a generic deobfuscator becuase Simplify doesn't need to know how the decryption works ahead of time. This technique also works well for eliminating different types of white noise, such as no-ops and useless arithmetic.
+For example, if an app's strings are encrypted, Simplify will interpret the app in its own virtual machine to determine semantics. Then, it uses the apps own code to decrypt the strings and replaces the encrypted strings and the decryption method calls with the decrypted versions. It's a generic deobfuscator because Simplify doesn't need to know how the decryption works ahead of time. This technique also works well for eliminating different types of white noise, such as no-ops and useless arithmetic.
 
 **Before / After**
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,9 +1,11 @@
 buildscript {
     repositories {
+    	mavenCentral()
         jcenter()
     }
 
     dependencies {
+        classpath 'org.kt3k.gradle.plugin:coveralls-gradle-plugin:2.0.1'
         classpath 'com.github.jengelman.gradle.plugins:shadow:1.0.3'
     }
 }
@@ -15,6 +17,7 @@ allprojects {
     }
 
     apply plugin: 'jacoco'
+    apply plugin: 'com.github.kt3k.coveralls'
     apply plugin: 'idea'
 }
 
@@ -24,6 +27,18 @@ subprojects {
     apply plugin: 'java'
     apply plugin: 'eclipse'
     apply plugin: 'com.github.johnrengelman.shadow'
+
+    jacocoTestReport {
+        reports {
+            html.enabled = true
+            xml.enabled = true
+            csv.enabled = false
+        }
+    }
+}
+
+coveralls {
+    sourceDirs = files(subprojects.sourceSets.main.allSource.srcDirs).files.absolutePath
 }
 
 // Thanks https://csiebler.github.io/blog/2014/02/09/multi-project-code-coverage-using-gradle-and-jacoco/
@@ -38,10 +53,11 @@ task codeCoverageReport(type: JacocoReport) {
     }
 
     reports {
-        xml.enabled true
-        html.enabled true
-        html.destination "${buildDir}/reports/jacoco"
-        csv.enabled false
+        xml.enabled = true
+        xml.destination = "${buildDir}/reports/jacoco/test/jacocoTestReport.xml"
+        html.enabled = true
+        html.destination = "${buildDir}/reports/jacoco"
+        csv.enabled = false
     }
 }
 

--- a/smalivm/build.gradle
+++ b/smalivm/build.gradle
@@ -21,8 +21,10 @@ dependencies {
     compile 'org.slf4j:slf4j-api:1.7.7'
 
     // Parsing and writing dex files
-    //compile 'org.smali:dexlib2:2.0.4'
-    compile files('../../smali/dexlib2/build/libs/dexlib2-2.0.3-dev.jar')
+    compile 'org.smali:dexlib2:2.0.3'
+    // Until dexlib2 2.0.4 is released you must clone/build the dev branch od dexlib2
+    // for smalivm to function properly
+    //compile files('../../smali/dexlib2/build/libs/dexlib2-2.0.3-dev.jar')
     compile 'org.smali:smali:2.0.3'
     compile 'org.smali:baksmali:2.0.3'
 


### PR DESCRIPTION
Pinning the libdex2 to 2.0.3 for CI purposes, though
it needs 2.0.4 (which is not released) for better support.

This will resolve/close #28.
