### PR TITLE
Add emulated function and enhance sdbg output

### DIFF
--- a/sdbg/src/main/java/org/cf/sdbg/command/ContinueCommand.kt
+++ b/sdbg/src/main/java/org/cf/sdbg/command/ContinueCommand.kt
@@ -20,6 +20,7 @@ class ContinueCommand : DebuggerCommand() {
                 parent.out.println("execution finished")
                 break
             } else if (debugger.isAtBreakpoint) {
+                parent.out.println("hit breakpoint " + number)
                 number--
             }
         }

--- a/smalivm/src/main/java/org/cf/smalivm/context/HeapItem.java
+++ b/smalivm/src/main/java/org/cf/smalivm/context/HeapItem.java
@@ -90,7 +90,7 @@ public class HeapItem {
     }
 
     public String getValueType() {
-        return ClassNameUtils.toInternal(getValue().getClass());
+        return isNull() ? "null" : ClassNameUtils.toInternal(getValue().getClass());
     }
 
     @Override

--- a/smalivm/src/main/java/org/cf/smalivm/emulate/MethodEmulator.java
+++ b/smalivm/src/main/java/org/cf/smalivm/emulate/MethodEmulator.java
@@ -17,6 +17,7 @@ public class MethodEmulator {
     private static Map<String, Class<? extends EmulatedMethod>> emulatedMethods = new HashMap<>();
 
     static {
+        addMethod("Landroid/text/TextUtils;->isEmpty(Ljava/lang/CharSequence;)Z", android_text_TextUtils_isEmpty.class);
         addMethod("Lorg/cf/simplify/Utils;->breakpoint()V", org_cf_simplify_Utils_breakpoint.class);
         addMethod("Ljava/lang/Class;->forName(Ljava/lang/String;)Ljava/lang/Class;", java_lang_Class_forName.class);
         addMethod("Ljava/lang/reflect/Field;->get(Ljava/lang/Object;)Ljava/lang/Object;", java_lang_reflect_Field_get.class);

--- a/smalivm/src/main/java/org/cf/smalivm/emulate/android_text_TextUtils_isEmpty.java
+++ b/smalivm/src/main/java/org/cf/smalivm/emulate/android_text_TextUtils_isEmpty.java
@@ -1,0 +1,32 @@
+package org.cf.smalivm.emulate;
+
+import org.cf.smalivm.VirtualMachine;
+import org.cf.smalivm.context.ExecutionContext;
+import org.cf.smalivm.context.MethodState;
+import org.cf.smalivm.dex.CommonTypes;
+import org.cf.smalivm.opcode.Op;
+import org.cf.smalivm.type.VirtualClass;
+import org.cf.util.ClassNameUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+class android_text_TextUtils_isEmpty extends ExecutionContextMethod {
+
+    @SuppressWarnings("unused")
+    private static final Logger log = LoggerFactory.getLogger(android_text_TextUtils_isEmpty.class.getSimpleName());
+
+    private static final String RETURN_TYPE = CommonTypes.BOOL;
+
+    @Override
+    public void execute(VirtualMachine vm, Op op, ExecutionContext context) {
+        
+        MethodState mState = context.getMethodState();
+        CharSequence charSequence = (CharSequence) mState.peekParameter(0).getValue();
+        
+        if (charSequence == null || charSequence.length() == 0) {
+            mState.assignReturnRegister(true, RETURN_TYPE);
+        } else {
+            mState.assignReturnRegister(false, RETURN_TYPE);
+        }
+    }
+}


### PR DESCRIPTION
While doing some reversing one of the `jiagu360` protectors, I wanted to test out `sdbg` and `simplify`. One of the easiest methods was failing and it seemed simple to fix -- hopefully I did it right.

Also added the breakpoint hit notification to `sdbg` so it will match `gdb`.