### PR TITLE
Refactored ExecutionGraphManipulatorTest to use TempDir annotation

### DIFF
--- a/simplify/src/test/java/org/cf/simplify/ExecutionGraphManipulatorTest.java
+++ b/simplify/src/test/java/org/cf/simplify/ExecutionGraphManipulatorTest.java
@@ -23,6 +23,7 @@ import org.jf.dexlib2.builder.instruction.BuilderInstruction21s;
 import org.jf.dexlib2.builder.instruction.BuilderInstruction30t;
 import org.jf.dexlib2.writer.io.FileDataStore;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 public class ExecutionGraphManipulatorTest {
 
@@ -289,7 +290,7 @@ public class ExecutionGraphManipulatorTest {
     }
 
     @Test
-    public void emptyingATryBlockWithTwoHandlersWhichCreatesNullStartAndEndLocationsIsRemovedWithoutIncident()
+    public void emptyingATryBlockWithTwoHandlersWhichCreatesNullStartAndEndLocationsIsRemovedWithoutIncident(@TempDir File tempDir)
             throws IOException {
         manipulator = OptimizerTester.getGraphManipulator(CLASS_NAME, "tryBlockWithTwoCatches()V");
         assertEquals(2, manipulator.getTryBlocks().size());
@@ -299,9 +300,8 @@ public class ExecutionGraphManipulatorTest {
 
         // Exception is thrown when saving. Make sure doesn't happen.
         ClassManager classManager = manipulator.getVM().getClassManager();
-        File out = File.createTempFile("test", "simplify");
+        File out = tempDir.createTempFile("test", "simplify");
         classManager.getDexBuilder().writeTo(new FileDataStore(out));
-        out.delete();
     }
 
     @Test


### PR DESCRIPTION
This is a test refactoring. No original assertion was changed and I tried to remove the flaky exception when saving.

Problem:
Tests that manipulate external file resources need to guarantee resource integrity and availability. Test suite design and maintainability may suffer from the addition of assurance steps to guarantee parallel execution scenarios and resource leakage from failed previous executions.

Solution:
The use of @tempdir annotation assures a temporary directory being created and cleaned up for every test method execution, thus simplifying test maintenance steps.