### PR TITLE
enable Gradle Daemon

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ before_script:
 - ps -e -o pid,vsz,comm= | sort -n -k 2
 - sudo free -m -t
 script:
-- ./gradlew test --no-daemon
+- ./gradlew test 
 after_success:
 - "./gradlew jacocoRootReport coveralls"
 before_cache:


### PR DESCRIPTION
[Gradle daemon](https://docs.gradle.org/current/userguide/gradle_daemon.html#header). The Daemon is a long-lived process that help to avoid the cost of JVM startup for every build. Since Gradle 3.0, Gradle daemon is enabled by default. For an older version, you should enable it by setting `org.gradle.daemon=true`.
